### PR TITLE
ci: add reusable testing workflow

### DIFF
--- a/.github/workflows/reusable_qa.yml
+++ b/.github/workflows/reusable_qa.yml
@@ -1,0 +1,45 @@
+name: reusable_qa
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: The name of the tarantool build artifact
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone the tarantool-php/queue connector
+        uses: actions/checkout@v2
+        with:
+          repository: tarantool-php/queue
+
+      - name: Download the tarantool build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - name: Install tarantool
+        # Now we're lucky: all dependencies are already installed. Check package
+        # dependencies when migrating to other OS version.
+        run: sudo dpkg -i tarantool*.deb
+
+      - name: Install the tarantool/queue module
+        run: tarantoolctl rocks install queue
+
+      - name: Build docker image with connector setup
+        run: ./dockerfile.sh | tee /dev/tty | docker build -t queue -
+        env:
+          TNT_LISTEN_URI: localhost:3301
+
+      - name: Run tarantool
+        run: tarantool ./tests/Integration/queues.lua > tarantool.log 2>&1 &
+        env:
+          TNT_LISTEN_URI: localhost:3301
+
+      - name: Run connector tests from docker container
+        run: docker run --rm --network=host -v $PWD:/queue -w /queue queue


### PR DESCRIPTION
The idea of this workflow is to be a part of the 'integration.yml'
workflow from the tarantool repo to verify the integration of the
tarantool-php/queue connector with an arbitrary tarantool version.

This workflow is not triggered on a push to the repo and cannot be run
manually since it has only the 'workflow_call' trigger. This workflow
will be included in the tarantool development cycle and called by the
'integration.yml' workflow from the tarantool project on a push to the
master and release branches for verifying integration of tarantool with
tarantool-php/queue.

Part of tarantool/tarantool#6595
Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056

Related to https://github.com/tarantool/tarantool/pull/6603