### PR TITLE
ci: bump actions to v4 in reusable_qa.yml

### DIFF
--- a/.github/workflows/reusable_qa.yml
+++ b/.github/workflows/reusable_qa.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone the tarantool-php/queue connector
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: tarantool-php/queue
 
       - name: Download the tarantool build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
Bump version of the `actions/checkout` and `actions/download-artifact` actions to v4 for fixing the following GitHub warning:

    The following actions uses node12 which is deprecated and will be
    forced to run on node16