### PR TITLE
ci: bump Ubuntu version in reusable_qa.yml

### DIFF
--- a/.github/workflows/reusable_qa.yml
+++ b/.github/workflows/reusable_qa.yml
@@ -5,13 +5,13 @@ on:
     inputs:
       artifact_name:
         description: The name of the tarantool build artifact
-        default: ubuntu-focal
+        default: ubuntu-noble
         required: false
         type: string
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the tarantool-php/queue connector
         uses: actions/checkout@v4


### PR DESCRIPTION
This patch bumps the Ubuntu distro version up to 24.04 (noble) in the aforementioned workflow, since the Ubuntu 20.04 (focal) image support will be dropped soon in the GitHub actions.

See also: actions/runner-images#11101

---
Needed for the https://github.com/tarantool/tarantool/pull/11220.